### PR TITLE
feat: Implement dynamic session expiration for admin users

### DIFF
--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -474,7 +474,11 @@ function AdminDashboard() {
         }
     }, 60000); // Every 60 seconds
 
-    return () => clearInterval(interval);
+    return () => {
+        clearInterval(interval);
+        // When the component unmounts, tell the server to shorten the session.
+        navigator.sendBeacon('/api/admin/session/expire-soon', new Blob());
+    };
   }, [navigate]);
 
   const handleAddNote = async (id, note) => {


### PR DESCRIPTION
This commit introduces a new, more intelligent session management system for the admin dashboard.

Key Features:
1.  **Dynamic Session `maxAge`:**
    -   The `express-session` configuration in `server.cjs` no longer uses a fixed global `maxAge`.
    -   Upon login, the admin session cookie is set to a long duration (24 hours).
    -   A `POST /api/admin/heartbeat` endpoint allows the client to periodically extend the session to the full 24-hour duration.
    -   A new `POST /api/admin/session/expire-soon` endpoint allows the client to shorten the session to 5 minutes.

2.  **Client-Side Triggers:**
    -   The `AdminDashboard.jsx` component now contains a `useEffect` hook to manage the session.
    -   A `setInterval` calls the heartbeat endpoint every minute, keeping the session alive while the admin is on the page.
    -   The `useEffect` cleanup function uses `navigator.sendBeacon` to call the `expire-soon` endpoint when the admin navigates away, reliably starting the 5-minute expiration countdown.